### PR TITLE
added chmod +x to Dockerfiles so start script can run

### DIFF
--- a/Dockerfile.omd-labs-centos
+++ b/Dockerfile.omd-labs-centos
@@ -17,6 +17,7 @@ RUN rpm -Uvh "https://labs.consol.de/repo/testing/rhel7/x86_64/labs-consol-testi
 ENV HOME=/root
 WORKDIR $HOME
 ADD ./scripts/centos/start.sh $HOME
+RUN chmod +x $HOME/start.sh
 
 #### ansible ################################################
 ARG ANSIBLE_DROPIN=$HOME/ansible_dropin

--- a/Dockerfile.omd-labs-debian
+++ b/Dockerfile.omd-labs-debian
@@ -27,6 +27,7 @@ RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ENV HOME=/root
 WORKDIR $HOME
 ADD ./scripts/debian/start.sh $HOME
+RUN chmod +x $HOME/start.sh
 
 #### ansible ################################################
 ARG ANSIBLE_DROPIN=$HOME/ansible_dropin

--- a/Dockerfile.omd-labs-ubuntu
+++ b/Dockerfile.omd-labs-ubuntu
@@ -27,6 +27,7 @@ RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ENV HOME=/root
 WORKDIR $HOME
 ADD ./scripts/ubuntu/start.sh $HOME
+RUN chmod +x $HOME/start.sh
 
 #### ansible ################################################
 ARG ANSIBLE_DROPIN=$HOME/ansible_dropin


### PR DESCRIPTION
Resolves Issue #4 where `CMD ["/root/start.sh"]` fails on container startup because the `start.sh` script is not executable inside the container.