### PR TITLE
support clean container shutdown

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -5,7 +5,7 @@ source /root/.sitename.env
 echo "Config and start OMD site: $SITENAME"
 echo "--------------------------------------"
 
-trap "omd stop $SITENAME; exit 0" SIGKILL SIGTERM SIGHUP SIGINT EXIT
+trap "omd stop $SITENAME; exit 0" SIGKILL SIGTERM SIGHUP SIGINT
 
 
 
@@ -97,4 +97,5 @@ echo
 echo "omd-labs: Starting Apache web server..."
 echo "--------------------------------------"
 
-`$APACHE_CMD`
+$APACHE_CMD &
+wait


### PR DESCRIPTION
Running the apache cmd in foreground prevents the traps handling. Instead we start apache as background process and use the builtin `wait` which still catches the traps.
Additionally the EXIT can be removed from the traps to not run the stop twice for no reason.