### PR TITLE
Appending to .lsyncd

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -15,6 +15,7 @@ trap "omd stop $SITENAME; exit 0" SIGKILL SIGTERM SIGHUP SIGINT
 
 echo "Checking for volume mounts..."
 echo "--------------------------------------"
+cat /dev/null > $OMD_ROOT/.lsyncd
 for dir in "local" "etc" "var"; do
   d_local="$OMD_ROOT/$dir"
   d_mount="$OMD_ROOT/${dir}.mount"


### PR DESCRIPTION
Hi 😃 

Currently if you restart the container for example with `docker compose restart` it will run the start.sh and append the settings to the .lsyncd file which will make the lsyncd process sync forever at some point.

Greetz
potter